### PR TITLE
use variables for paths to 3rd-party modules

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -19,9 +19,11 @@ shared.sources = abl_link_instance.cpp
 # all extra files to be included in binary distribution of the library
 datafiles = abl_link~-help.pd ../LICENSE
 
-LINK_HOME ?= ./link
-cflags = -std=c++11 -I$(LINK_HOME)/include \
-	 -I$(LINK_HOME)/modules/asio-standalone/asio/include -Wno-multichar
+LINK_INCLUDES ?= ./link/include
+ASIO_INCLUDES ?= ./link/modules/asio-standalone/asio/include
+
+cflags = -std=c++11 -I$(LINK_INCLUDE) \
+	 -I$(ASIO_INCLUDES) -Wno-multichar
     
 suppress-wunused = yes
 

--- a/external/Makefile
+++ b/external/Makefile
@@ -40,5 +40,5 @@ define forWindows
   cflags += -DLINK_PLATFORM_WINDOWS=1
 endef
 
-PDLIBBUILDERDIR=pd-lib-builder
+PDLIBBUILDERDIR ?= pd-lib-builder
 include $(PDLIBBUILDERDIR)/Makefile.pdlibbuilder

--- a/external/Makefile
+++ b/external/Makefile
@@ -38,4 +38,5 @@ define forWindows
   cflags += -DLINK_PLATFORM_WINDOWS=1
 endef
 
-include pd-lib-builder/Makefile.pdlibbuilder
+PDLIBBUILDERDIR=pd-lib-builder
+include $(PDLIBBUILDERDIR)/Makefile.pdlibbuilder


### PR DESCRIPTION
Closes https://github.com/libpd/pd-for-ios/issues/12

my use case is simple: i want to have `abl_link~` in Debian.
there are a few obstacles:
- Debian prefers upstream tarballs (as opposed to git repositories)
- Debian *prohibits* verbatim inclusion of 3rd party dependencies (for which you are using `git submodules`)
  - it's obviously cooler to maintain (and fix security issues) of `libfoo` only once, rather than to include it verbatim in thousands of packages.

these obstacles are further supported by github, which doesn't include any `git submodules` into any generated zipfiles/tarballs (think tagged releases)

luckily, Debian has packaged both `libasio` and `ableton_link` (resp. their headers).
Of course, the `libasio` header files (in `/usr/include/asio`) are independently usable of `ableton-link`, so they are not found in some random subdirectory of the abelton headers (in `/usr/include/ableton`).

unfortunately some compilers are rather picky when passing them non-existent include-directories (`-I/path/to/nowhere`).
and since you are using `cflags`, those flags cannot be overwritten via the cmdline.

so i think it is better to make the include-paths for each 3rd-party library *explicit* and *overridable*.
