### PR TITLE
Allow to dynamically adjust latency compensation

### DIFF
--- a/external/abl_link_instance.hpp
+++ b/external/abl_link_instance.hpp
@@ -25,7 +25,7 @@ class AblLinkWrapper {
   void enable(bool enabled);
 
   ableton::Link::Timeline&
-      acquireAudioTimeline(std::chrono::microseconds *current_time);
+      acquireAudioTimeline(std::chrono::microseconds *current_time, double advance_ms);
 
   void releaseAudioTimeline();
 

--- a/external/abl_link~-help.pd
+++ b/external/abl_link~-help.pd
@@ -1,20 +1,20 @@
-#N canvas 100 23 569 662 10;
-#X msg 366 443 tempo \$1;
-#X msg 155 444 resolution \$1;
-#X msg 258 464 reset \$1 \$2;
-#X obj 258 443 pack f f;
-#X floatatom 265 562 5 0 0 1 beat_time - -, f 5;
-#X floatatom 228 580 5 0 0 1 phase - -, f 5;
-#X msg 87 553 \; pd dsp 1;
-#X floatatom 191 602 5 0 0 1 step - -, f 5;
-#X floatatom 302 541 5 0 0 1 tempo - -, f 5;
-#X obj 78 424 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+#N canvas 98 82 579 662 10;
+#X msg 330 441 tempo \$1;
+#X msg 119 442 resolution \$1;
+#X msg 222 462 reset \$1 \$2;
+#X obj 222 441 pack f f;
+#X floatatom 229 560 5 0 0 1 beat_time - -, f 5;
+#X floatatom 192 578 5 0 0 1 phase - -, f 5;
+#X msg 51 551 \; pd dsp 1;
+#X floatatom 155 600 5 0 0 1 step - -, f 5;
+#X floatatom 266 539 5 0 0 1 tempo - -, f 5;
+#X obj 42 422 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
 1;
-#X obj 191 516 abl_link~ 1 0 4 134;
-#X floatatom 366 424 5 0 0 2 tempo - -, f 5;
-#X floatatom 303 424 5 0 0 2 quantum - -, f 5;
-#X floatatom 258 424 5 0 0 2 beat - -, f 5;
-#X floatatom 155 424 5 0 0 2 resolution - -, f 5;
+#X obj 155 514 abl_link~ 1 0 4 134;
+#X floatatom 330 422 5 0 0 2 tempo - -, f 5;
+#X floatatom 267 422 5 0 0 2 quantum - -, f 5;
+#X floatatom 222 422 5 0 0 2 beat - -, f 5;
+#X floatatom 119 422 5 0 0 2 resolution - -, f 5;
 #X text 25 44 abl_link~ is a Pd external that integrates Ableton Link
 into Pd. It has four outlets \, which emit the index of the current
 step (at the beginning of each step) \, the current phase and beat
@@ -33,7 +33,7 @@ well as the quantum (default 4) and tempo (default 120) \, which will
 be replaced by the session tempo if the Link instance is already connected.
 The Link external will perform a quantized launch on creation., f
 85;
-#X msg 78 444 connect \$1;
+#X msg 42 442 connect \$1;
 #X text 25 116 abl_link~ responds to four methods \, for connecting
 with other Link instances \, for setting the resolution of the step
 outlet (in steps per beat) \, the tempo (in beats per minute) \, and
@@ -42,14 +42,16 @@ launch., f 85;
 #X text 25 293 The Link external emits events as soon as DSP is enabled
 in Pd. It will only connect with other Link instances \, however \,
 if you send it the message [connect 1(., f 85;
-#X floatatom 371 507 5 0 0 0 - - -, f 5;
-#X obj 371 485 r #abl_link_num_peers;
+#X floatatom 335 505 5 0 0 0 - - -, f 5;
+#X obj 335 483 r #abl_link_num_peers;
 #X text 25 24 abl_link~: Ableton Link external;
 #X text 25 327 All instances of abl_link~ will share the same underlying
 Link instance under the hood. In particular \, they will all be in
 sync with one another \, and they will all be connected as soon as
 one of them is connected. They may \, however \, have different quanta
 and resolutions., f 85;
+#X msg 401 441 advance \$1;
+#X floatatom 401 422 5 0 0 2 latency_compensation(ms) - -, f 5;
 #X connect 0 0 10 0;
 #X connect 1 0 10 0;
 #X connect 2 0 10 0;
@@ -65,3 +67,5 @@ and resolutions., f 85;
 #X connect 14 0 1 0;
 #X connect 18 0 10 0;
 #X connect 22 0 21 0;
+#X connect 25 0 10 0;
+#X connect 26 0 25 0;


### PR DESCRIPTION
For now latency compensation is the same for every instances, because only one timeline is shared. As only the first instance will initialize this timeline, I used a common static "advance" variable to allow any instance to change effectively the latency compensation.