### PR TITLE
Removed .aar import step from build process

### DIFF
--- a/AblLinkSample/app/build.gradle
+++ b/AblLinkSample/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
     defaultConfig {
         applicationId "com.noisepages.nettoyeur.abllinksample"
         minSdkVersion 10
@@ -32,7 +32,6 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile 'com.android.support:appcompat-v7:25.0.0'
-    compile project(":pd-core-1.0.3-SNAPSHOT")
+    compile project(':PdCore')
     testCompile 'junit:junit:4.12'
-    compile 'com.google.android.gms:play-services-appindexing:8.4.0'
 }

--- a/AblLinkSample/app/src/main/AndroidManifest.xml
+++ b/AblLinkSample/app/src/main/AndroidManifest.xml
@@ -14,12 +14,8 @@
 
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
-        </activity><!-- ATTENTION: This was auto-generated to add Google Play services to your project for
-     App Indexing.  See https://g.co/AppIndexing/AndroidStudio for more information. -->
+        </activity>
         <service android:name="org.puredata.android.service.PdService" />
-        <meta-data
-            android:name="com.google.android.gms.version"
-            android:value="@integer/google_play_services_version" />
     </application>
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/AblLinkSample/build.gradle
+++ b/AblLinkSample/build.gradle
@@ -6,6 +6,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -20,4 +22,9 @@ allprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
+}
+
+ext {
+    compileSdkVersion = 25
+    buildToolsVersion = '25.0.0'
 }

--- a/AblLinkSample/settings.gradle
+++ b/AblLinkSample/settings.gradle
@@ -1,1 +1,2 @@
-include ':app', ':pd-core-1.0.3-SNAPSHOT'
+include ':app', ':PdCore'
+project(':PdCore').projectDir = new File(settingsDir, '../../pd-for-android/PdCore')

--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ Android development. If you'd like to add Link to your own app, check out the
 README in the `android` directory.
 
 * Set up your build environment following these instructions: https://developer.android.com/studio/projects/add-native-code.html
-* Clone Pd for Android and set it up to build from source (just adding a dependency via jcenter is not enough): https://github.com/libpd/pd-for-android#using-android-studio
-* Clone this repository into the same parent directory as Pd for Android. (You can put it somewhere else, but then you'll have to adjust `android/CMakeLists.txt` accordingly.)
-* Open AblLinkSample in Android Studio and add PdCore as an AAR package: File > New Module > Import .JAR/.AAR Package. The location of the AAR package should look like `pd-for-android/PdCore/build/outputs/aar/pd-core-1.0.3-SNAPSHOT.aar`.
+* Clone Pd for Android : https://github.com/libpd/pd-for-android
+* Clone this repository into the same parent directory as Pd for Android. (You can put it somewhere else, but then you'll have to adjust `android/CMakeLists.txt` and `AblLinkSample/settings.gradle` accordingly.)
 * Now you should be able to build and run the sample app.
 
 ## iOS version


### PR DESCRIPTION
The current build instructions that require importing an .aar module did not work as described. I had to delete the reference to pd-core from settings.gradle and build.gradle, and then go through the manual process of importing the .aar to make it work.

Instead of manually importing the .aar , I'm proposing here a simpler build process which also eliminates the need to build PdCore separately, by making PdCore a project that is included in the build process of the sample app. See updated instructions in the README file.

I also removed the unused google play services dependency and and added some dependencies to make PdCore build.