### PR TITLE
Launch sample activity in single task mode

### DIFF
--- a/AblLinkSample/app/src/main/AndroidManifest.xml
+++ b/AblLinkSample/app/src/main/AndroidManifest.xml
@@ -8,14 +8,15 @@
             android:label="@string/app_name"
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity" android:screenOrientation="portrait">
+        <activity android:name=".MainActivity" android:screenOrientation="portrait"
+                  android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-        <service android:name="org.puredata.android.service.PdService" />
+        <service android:name="org.puredata.android.service.PdService"/>
     </application>
-    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>


### PR DESCRIPTION
This fixes an issue where a new activity (and another abl_link~ instance) is created on top of the existing one when pressing the notification.