### PR TITLE
exclude .git* files from generated tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git* export-ignore


### PR DESCRIPTION
this excludes the `.gitignore` file from the generated tarball (as can be downloaded via github; or produced via `git archive`).
it also excludes `.gitattributes`, or really anything that matches `.git*`.

since the generated tarballs lack the `.git` directory, these files are useless at best (and harmful in a few cases).