### PR TITLE
Help patch: Add notes about offset message

### DIFF
--- a/external/abl_link~-help.pd
+++ b/external/abl_link~-help.pd
@@ -1,46 +1,41 @@
-#N canvas 100 23 416 755 10;
-#X msg 351 519 tempo \$1;
-#X msg 165 519 resolution \$1;
-#X msg 261 519 reset \$1 \$2;
-#X obj 261 498 pack f f;
-#X floatatom 195 645 5 0 0 1 beat_time - -, f 5;
-#X floatatom 167 666 5 0 0 1 phase - -, f 5;
-#X msg 36 619 \; pd dsp 1;
-#X floatatom 140 694 5 0 0 1 step - -, f 5;
-#X floatatom 223 623 5 0 0 1 tempo - -, f 5;
-#X obj 22 499 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+#N canvas 100 86 912 528 10;
+#X msg 750 106 tempo \$1;
+#X msg 564 106 resolution \$1;
+#X msg 660 106 reset \$1 \$2;
+#X obj 660 85 pack f f;
+#X floatatom 594 232 5 0 0 1 beat_time - -;
+#X floatatom 566 253 5 0 0 1 phase - -;
+#X msg 435 206 \; pd dsp 1;
+#X floatatom 539 281 5 0 0 1 step - -;
+#X floatatom 622 210 5 0 0 1 tempo - -;
+#X obj 421 86 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
 1;
-#X obj 140 582 abl_link~ 1 0 4 134;
-#X floatatom 351 500 5 0 0 2 tempo - -, f 5;
-#X floatatom 306 479 5 0 0 2 quantum - -, f 5;
-#X floatatom 261 479 5 0 0 2 beat - -, f 5;
-#X floatatom 165 499 5 0 0 2 resolution - -, f 5;
-#X text 25 331 Link's beat time can sometimes go backwards. When this
+#X obj 539 169 abl_link~ 1 0 4 134;
+#X floatatom 750 87 5 0 0 2 tempo - -;
+#X floatatom 705 66 5 0 0 2 quantum - -;
+#X floatatom 660 66 5 0 0 2 beat - -;
+#X floatatom 564 86 5 0 0 2 resolution - -;
+#X text 25 344 Link's beat time can sometimes go backwards. When this
 happens \, the step outlet will fall silent until the beat time moves
 forward again. The phase and beat outlets will output raw values from
 Link so that patches can implement their own handling of time going
 backwards.;
-#X text 25 238 The creation arguments \, all optional \, specify the
+#X text 25 251 The creation arguments \, all optional \, specify the
 resolution (default 1) and the initial beat time (default 0) \, as
 well as the quantum (default 4) and tempo (default 120) \, which will
 be replaced by the session tempo if the Link instance is already connected.
 The Link external will perform a quantized launch on creation.;
-#X msg 22 520 connect \$1;
-#X text 25 411 The Link external emits events as soon as DSP is enabled
+#X msg 421 107 connect \$1;
+#X text 25 424 The Link external emits events as soon as DSP is enabled
 in Pd. It will only connect with other Link instances \, however \,
 if you send it the message [connect 1(.;
-#X floatatom 248 713 5 0 0 0 - - -, f 5;
-#X obj 248 691 r #abl_link_num_peers;
+#X floatatom 647 300 5 0 0 0 - - -;
+#X obj 647 278 r #abl_link_num_peers;
 #X text 25 24 abl_link~: Ableton Link external;
-#X floatatom 251 604 5 0 0 1 is_playing - -, f 5;
-#X obj 105 499 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+#X floatatom 650 191 5 0 0 1 is_playing - -;
+#X obj 504 86 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
 1;
-#X msg 105 519 play \$1;
-#X text 25 158 abl_link~ responds to five methods \, for connecting
-with other Link instances \, for setting the resolution of the step
-outlet (in steps per beat) \, the tempo (in beats per minute) \, the
-play state (on or off) \, and for resetting the beat time and quantum
-by having Link perform a quantized launch.;
+#X msg 504 106 play \$1;
 #X text 25 52 abl_link~ is a Pd external that integrates Ableton Link
 into Pd. It has five outlets \, which emit the index of the current
 step (at the beginning of each step) \, the current phase and beat
@@ -48,6 +43,27 @@ time on each DSP tick \, the tempo on tempo changes \, as well as the
 play state. Phase and beat time are Link concepts. The purpose of the
 step feature is to generate events in Pd at a given rate (measured
 in steps per beat).;
+#N canvas 213 167 446 262 offset_vs_audio_latency 0;
+#X text 37 29 Ableton defines its grid time as the moment when the
+sound should hit the speakers. This means connected apps must \, on
+their own \, account for audio driver latency and any other calculation
+latencies.;
+#X text 37 94 Pure Data does not currently make the audio driver latency
+available to objects. When you run abl_link~ against other apps \,
+then \, Pure Data may sound some milliseconds late.;
+#X text 37 149 abl_link~ responds to an [offset( message by shifting
+its timebase earlier by the given number of milliseconds. At worst
+\, then \, users may sync with non-Pd apps (or with Pd running under
+different audio settings) by manually setting the offset. It's easy
+to tune by hand/ear.;
+#X restore 119 483 pd offset_vs_audio_latency;
+#X floatatom 820 87 5 0 0 0 - - -;
+#X msg 820 106 offset \$1;
+#X text 25 158 abl_link~ responds to six methods \, for connecting
+with other Link instances \, for setting the resolution of the step
+outlet (in steps per beat) \, the tempo (in beats per minute) \, the
+play state (on or off) \, the latency offset \, and for resetting the
+beat time and quantum by having Link perform a quantized launch.;
 #X connect 0 0 10 0;
 #X connect 1 0 10 0;
 #X connect 2 0 10 0;
@@ -57,7 +73,6 @@ in steps per beat).;
 #X connect 10 1 5 0;
 #X connect 10 2 4 0;
 #X connect 10 3 8 0;
-#X connect 10 4 22 0;
 #X connect 11 0 0 0;
 #X connect 12 0 3 1;
 #X connect 13 0 3 0;
@@ -66,3 +81,5 @@ in steps per beat).;
 #X connect 20 0 19 0;
 #X connect 23 0 24 0;
 #X connect 24 0 10 0;
+#X connect 27 0 28 0;
+#X connect 28 0 10 0;


### PR DESCRIPTION
Per discussion under #20, this PR adds information about the "offset" message.

Also some reformatting to be friendlier for landscape-style laptop screens. (The bottom part was invisible with the original formatting, made it hard to add new content.)