### PR TITLE
Windows compilation

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -15,7 +15,7 @@ lib.name = abl_link~
 abl_link~.class.sources = abl_link~.cpp abl_link_instance.cpp
 
 # all extra files to be included in binary distribution of the library
-datafiles = abl_link~-help.pd ../LICENSE
+datafiles = abl_link~-help.pd ../LICENSE metronome.pd
 
 LINK_INCLUDES ?= ./link/include
 ASIO_INCLUDES ?= ./link/modules/asio-standalone/asio/include
@@ -33,9 +33,10 @@ define forDarwin
   cflags += -DLINK_PLATFORM_MACOSX=1 -mmacosx-version-min=10.9
 endef
 
-# TODO: Windows build untested
+
 define forWindows
   cflags += -DLINK_PLATFORM_WINDOWS=1
+  ldlibs += -lws2_32 -liphlpapi -static -lpthread
 endef
 
 PDLIBBUILDERDIR ?= .

--- a/external/Makefile.pdlibbuilder
+++ b/external/Makefile.pdlibbuilder
@@ -1,10 +1,13 @@
-# Makefile.pdlibbuilder dated 2016-11-02
-version = 0.4.3
+# Makefile.pdlibbuilder dated 2019-12-21
+version = 0.6.0
 
 # Helper makefile for Pure Data external libraries.
 # Written by Katja Vetter March-June 2015 for the public domain. No warranties.
 # Inspired by Hans Christoph Steiner's Makefile Template and Stephan Beal's
 # ShakeNMake.
+#
+# Grab the newest version of Makefile.pdlibbuilder from
+#    https://github.com/pure-data/pd-lib-builder/
 #
 # GNU make version >= 3.81 required.
 #
@@ -93,11 +96,15 @@ version = 0.4.3
 # - CC
 # - CXX
 # - INSTALL
+# - STRIP
 # - DESTDIR
+#
+# Optional user variables for make command line or environment:
+#
+# - PLATFORM
 #
 # Deprecated path variables:
 #
-# - PD_PATH
 # - pdincludepath
 # - pdbinpath
 # - objectsdir
@@ -106,7 +113,7 @@ version = 0.4.3
 #=== descriptions of Makefile.pdlibbuilder API variables =======================
 #
 #
-# lib.name: 
+# lib.name:
 # Name of the library directory as it will be installed / distributed. Also the
 # name of the lib executable in the case where all classes are linked into
 # a single binary.
@@ -116,7 +123,7 @@ version = 0.4.3
 # into a single lib binary.
 #
 # class.sources:
-# All sources files (C or C++) for which the condition holds that 
+# All sources files (C or C++) for which the condition holds that
 # class name == source file basename.
 #
 # <classname>.class.sources:
@@ -135,13 +142,13 @@ version = 0.4.3
 # link libs) for the whole library. These flags are added to platform-specific
 # flags defined by Makefile.pdlibbuilder.
 #
-# <classname>.class.ldflags and <classname>.class.ldlibs: 
+# <classname>.class.ldflags and <classname>.class.ldlibs:
 # Define ldflags resp. ldlibs specific to class <classname>. These flags are
 # added to platform-specific flags defined by Makefile.pdlibbuilder, and flags
 # defined in your Makefile for the whole library. Note: cflags can not be
 # defined per class in the current implementation.
 #
-# datafiles and datadirs: 
+# datafiles and datadirs:
 # All extra files you want to include in binary distributions of the
 # library: abstractions and help patches, example patches, meta patch, readme
 # and license texts, manuals, sound files, etcetera. Use 'datafiles' for all
@@ -155,7 +162,7 @@ version = 0.4.3
 #      class.sources += linuxthing.c
 #    endef
 #
-# makefiles and makefiledirs: 
+# makefiles and makefiledirs:
 # Extra makefiles or directories with makefiles that should be made in sub-make
 # processes.
 #
@@ -164,7 +171,7 @@ version = 0.4.3
 # Makefile.pdlibbuilder will try to build all classes into a single library
 # executable (but it will force exit if lib.setup.sources is undefined).
 # If your makefile defines 'make-lib-executable=yes' as the library default,
-# this can still be overriden with 'make-lib-executable=no' as command argument 
+# this can still be overridden with 'make-lib-executable=no' as command argument
 # to build individual class executables (the Makefile.pdlibbuilder default.)
 #
 # suppress-wunused:
@@ -173,7 +180,7 @@ version = 0.4.3
 # but the other warnings from -Wall are retained.
 #
 # PDDIR:
-# Root directory of 'portable' pd package. When defined, PDINCLUDEDIR and 
+# Root directory of 'portable' pd package. When defined, PDINCLUDEDIR and
 # PDBINDIR will be evaluated as $(PDDIR)/src and $(PDDIR)/bin.
 #
 # PDINCLUDEDIR:
@@ -190,6 +197,13 @@ version = 0.4.3
 #
 # DESTDIR:
 # Prepended path component for staged install.
+#
+# PLATFORM:
+# Target platform for cross compilation in the form of GNU triplet:
+# cpu-vendor-os. Example: x86_64-w64-mingw32. This specifies the tool chain that
+# pdlibbuilder will use, if installed and locatable. System and architecture
+# will then be autodefined accordingly. In most cases no other variables need to
+# be overridden.
 #
 # CPPFLAGS:
 # Preprocessor flags which are not strictly required for building.
@@ -210,9 +224,9 @@ version = 0.4.3
 # INSTALL
 # Definition of install program.
 #
-# PD_PATH:
-# Equivalent to PDDIR. Supported for compatibility with pd-extended central
-# makefile, but deprecated otherwise.
+# STRIP
+# Name of strip program. Default 'strip' can be overridden in cross compilation
+# environments.
 #
 # objectsdir:
 # Root directory for installation of Pd library directories, like PDLIBDIR but
@@ -230,16 +244,22 @@ version = 0.4.3
 # Source files in directories other than current working directory must be
 # prefixed with their relative path. Do not rely on VPATH or vpath.
 # Object (.o) files are built in the directory of their source files.
-# Executables are built in current working directory. 
+# Executables are built in current working directory.
 #
-# Default search path for m_pd.h and other API header files is platform 
+# Default search path for m_pd.h and other API header files is platform
 # dependent, and overridable by PDINCLUDEDIR:
 #
 # Linux:    /usr/include/pd
 #
 # OSX:      /Applications/Pd*.app/Contents/Resources/src
 #
-# Windows:  %PROGRAMFILES%/pd/src
+# Windows:  %PROGRAMFILES%/Pd/src
+#           %PROGRAMFILES(X86)%/Pd/src (32 bit builds on 64 bit Windows)
+#
+# Default search path for binary pd.dll (Windows), overridable by PDBINDIR
+#
+#           %PROGRAMFILES%/Pd/bin
+#           %PROGRAMFILES(X86)%/Pd/bin (32 bit builds on 64 bit Windows)
 #
 # Default location to install pd libraries is platform dependent, and
 # overridable by PDLIBDIR:
@@ -270,6 +290,7 @@ version = 0.4.3
 # vars: print makefile variables
 # allvars: print all variables
 # depend: print generated prerequisites
+# dumpmachine: print compiler output of option '-dumpmachine'
 # coffee: dummy target
 #
 # Variable $(executables) expands to class executables plus optional shared lib,
@@ -301,7 +322,7 @@ version = 0.4.3
 # are upper case. Use target 'allvars' to print all variables and their values.
 #
 # 'Fields' in data variables are separated by dots, like in 'foo.class.sources'.
-# Words in variables expressing a function or command are separated by dashes, 
+# Words in variables expressing a function or command are separated by dashes,
 # like in 'make-lib-executable'.
 #
 #
@@ -318,14 +339,13 @@ version = 0.4.3
 # - decide whether to use -static-libgcc or shared dll in MinGW
 # - cygwin support
 # - android support
-# - Windows 64 bit support
 # - figure out how to handle '$' in filenames
 # - add makefile template targets dpkg-source dist libdir distclean tags?
 #
 #
 #=== end of documentation sections =============================================
 #
-# 
+#
 ################################################################################
 ################################################################################
 ################################################################################
@@ -340,13 +360,305 @@ ifneq ($(firstword $(sort 3.81 $(MAKE_VERSION))), 3.81)
   $(error GNU make version 3.81 or higher is required)
 endif
 
-# Relative path to externals root dir in multi-lib source tree like 
+# Relative path to externals root dir in multi-lib source tree like
 # pd-extended SVN. Default is parent of current working directory. May be
 # defined differently in including makefile.
 externalsdir ?= ..
 
 # variable you can use to check if Makefile.pdlibbuilder is already included
 Makefile.pdlibbuilder = true
+
+
+################################################################################
+### target platform detection ##################################################
+################################################################################
+
+
+#=== target platform ===========================================================
+
+
+# PLATFORM: optional user variable to define target platform for cross
+# compilation. Redefine build tools accordingly. PLATFORM should match
+# the exact target prefix of tools present in $PATH, like x86_64-w64-mingw32,
+# x86_64-apple-darwin12 etc. Tool definitions are exported to ensure submakes
+# will get the same.
+
+ifneq ($(PLATFORM),)
+  ifneq ($(findstring darwin, $(PLATFORM)),)
+    export CC = $(PLATFORM)-cc
+    export CXX = $(PLATFORM)-c++
+    export CPP = $(PLATFORM)-cc
+  else
+    export CC = $(PLATFORM)-gcc
+    export CXX = $(PLATFORM)-g++
+    export CPP = $(PLATFORM)-cpp
+  endif
+  STRIP = $(PLATFORM)-strip
+endif
+
+# Let (native or cross-) compiler report target triplet and isolate individual
+# words therein to facilitate later processing.
+target.triplet := $(subst -, ,$(shell $(CC) -dumpmachine))
+
+
+#=== operating system ==========================================================
+
+
+# The following systems are defined: Linux, Darwin, Windows. GNU and
+# GNU/kFreeBSD are treated as Linux to get the same options.
+
+ifneq ($(filter linux gnu% kfreebsd, $(target.triplet)),)
+  system = Linux
+endif
+
+ifneq ($(filter darwin%, $(target.triplet)),)
+  system = Darwin
+endif
+
+ifneq ($(filter mingw% cygwin%, $(target.triplet)),)
+  system = Windows
+endif
+
+# evaluate possible system-specific multiline defines from library makefile
+$(eval $(for$(system)))
+
+
+# TODO: Cygwin, Android
+
+
+#=== architecture ==============================================================
+
+
+# The following CPU names can be processed by pdlibbuilder:
+# i*86    Intel 32 bit
+# x86_64  Intel 64 bit
+# arm     ARM 32 bit
+# aarch64 ARM 64 bit
+
+target.arch := $(firstword $(target.triplet))
+
+
+################################################################################
+### variables per platform #####################################################
+################################################################################
+
+
+#=== flags per architecture ====================================================
+
+
+# Set architecture-dependent cflags, mainly for Linux. For Mac and Windows,
+# arch.c.flags are overriden below. To see gcc's default architecture flags:
+# $ gcc -Q --help=target
+
+# ARMv6: Raspberry Pi 1st gen, not detectable from target.arch
+ifeq ($(shell uname), armv6l)
+  arch.c.flags = -march=armv6 -mfpu=vfp -mfloat-abi=hard
+
+# ARMv7: Beagle, Udoo, RPi2 etc.
+else ifeq ($(target.arch), arm)
+  arch.c.flags = -march=armv7-a -mfpu=vfpv3 -mfloat-abi=hard
+
+# ARMv8 64 bit, not tested yet
+else ifeq ($(target.arch), aarch64)
+  arch.c.flags = -mcpu=cortex-a53
+
+# Intel 32 bit, build with SSE and SSE2 instructions
+else ifneq ($(filter i%86, $(target.arch)),)
+  arch.c.flags = -march=pentium4 -mfpmath=sse -msse -msse2
+
+# Intel/AMD 64 bit, build with SSE, SSE2 and SSE3 instructions
+else ifeq ($(target.arch), x86_64)
+  arch.c.flags = -march=core2 -mfpmath=sse -msse -msse2 -msse3
+
+# if none of the above architectures detected
+else
+  arch.c.flags =
+endif
+
+
+#=== flags and paths for Linux =================================================
+
+
+ifeq ($(system), Linux)
+  prefix = /usr/local
+  libdir := $(prefix)/lib
+  pkglibdir = $(libdir)/pd-externals
+  pdincludepath := $(wildcard /usr/include/pd)
+  extension = pd_linux
+  cpp.flags := -DUNIX
+  c.flags := -fPIC
+  c.ldflags := -rdynamic -shared -fPIC -Wl,-rpath,"\$$ORIGIN",--enable-new-dtags
+  c.ldlibs := -lc -lm
+  cxx.flags := -fPIC -fcheck-new
+  cxx.ldflags := -rdynamic -shared -fPIC -Wl,-rpath,"\$$ORIGIN",--enable-new-dtags
+  cxx.ldlibs := -lc -lm -lstdc++
+  shared.extension = so
+  shared.ldflags = -rdynamic -fPIC -shared -Wl,-soname,$(shared.lib)
+endif
+
+
+#=== flags and paths for Darwin ================================================
+
+
+# LLVM-clang doesn't support -fcheck-new, therefore this flag is only used when
+# compiling with g++.
+
+ifeq ($(system), Darwin)
+  pkglibdir = $(HOME)/Library/Pd
+  pdincludepath := $(firstword $(wildcard \
+    /Applications/Pd*.app/Contents/Resources/src))
+  extension = pd_darwin
+  cpp.flags := -DUNIX -DMACOSX -I /sw/include
+  c.flags :=
+  c.ldflags := -undefined suppress -flat_namespace -bundle
+  c.ldlibs := -lc
+  cxx.ldflags := -undefined suppress -flat_namespace -bundle
+  cxx.ldlibs := -lc
+  shared.extension = dylib
+  shared.ldflags = -dynamiclib -undefined dynamic_lookup \
+    -install_name @loader_path/$(shared.lib) \
+    -compatibility_version 1 -current_version 1.0
+  ifneq ($(filter %g++, $(CXX)),)
+    cxx.flags := -fcheck-new
+  endif
+  ifeq ($(extension), d_fat)
+    arch := i386 x86_64
+  else
+    arch := $(target.arch)
+  endif
+  ifneq ($(filter -mmacosx-version-min=%, $(cflags)),)
+    version.flag := $(filter -mmacosx-version-min=%, $(cflags))
+  else
+    version.flag = -mmacosx-version-min=10.6
+  endif
+  arch.c.flags := $(addprefix -arch , $(arch)) $(version.flag)
+  arch.ld.flags := $(arch.c.flags)
+endif
+
+
+#=== flags and paths for Windows ===============================================
+
+
+# Standard paths on Windows contain spaces, and GNU make functions treat such
+# paths as lists, with unintended effects. Therefore we must use shell function
+# ls instead of make's wildcard when probing for a path, and use double quotes
+# when specifying a path in a command argument.
+
+# Default paths in Mingw / Mingw-w64 environments. 'PROGRAMFILES' is standard
+# location for builds with native architecture, 'ProgramFiles(x86)' for i686
+# builds on x86_64 Windows (detection method by Lucas Cordiviola). Curly braces
+# required because of parentheses in variable name.
+ifeq ($(system), Windows)
+  pkglibdir := $(APPDATA)/Pd
+  ifeq ($(target.arch), i686)
+    programfiles := ${ProgramFiles(x86)}
+  else
+    programfiles := $(PROGRAMFILES)
+  endif
+  pdbinpath := $(programfiles)/Pd/bin
+  pdincludepath := $(programfiles)/Pd/src
+endif
+
+# Store default path to pd.dll in PDBINDIR if the latter is not user-defined.
+# For include path this is done in the platform-independent paths section below,
+# but for PDBINDIR it is done here so ld flags can be evaluated as immediate
+# variables.
+ifeq ($(system), Windows)
+  ifdef PDDIR
+    PDBINDIR := $(PDDIR)/bin
+  endif
+  PDBINDIR ?= $(pdbinpath)
+endif
+
+# TODO: decide whether -mms-bitfields should be specified.
+ifeq ($(system), Windows)
+  cpp.flags := -DMSW -DNT
+  ifeq ($(target.arch), i686)
+     arch.c.flags := -march=pentium4 -msse -msse2 -mfpmath=sse
+  else ifeq ($(target.arch), x86_64)
+    cpp.flags := -DMSW -DNT -DPD_LONGINTTYPE=__int64
+    arch.c.flags := -march=core2 -msse -msse2 -msse3 -mfpmath=sse
+  else
+    arch.c.flags =
+  endif
+  extension = dll
+  c.flags :=
+  c.ldflags := -static-libgcc -shared \
+    -Wl,--enable-auto-import "$(PDBINDIR)/pd.dll"
+  c.ldlibs :=
+  cxx.flags := -fcheck-new
+  cxx.ldflags := -static-libgcc -static-libstdc++ -shared \
+    -Wl,--enable-auto-import "$(PDBINDIR)/pd.dll"
+  cxx.ldlibs :=
+  shared.extension = dll
+  shared.ldflags := -static-libgcc -shared "$(PDBINDIR)/pd.dll"
+  stripflags = --strip-all
+endif
+
+
+#=== paths =====================================================================
+
+
+# Platform-dependent default paths are specified above, but overridable.
+# Path variables in upper case can be defined as make command argument or in the
+# environment. Variable 'objectsdir' is supported for compatibility with
+# the build system that pd-l2ork has inherited from pd-extended.
+
+PDINCLUDEDIR ?= $(pdincludepath)
+PDLIBDIR ?= $(firstword $(objectsdir) $(pkglibdir))
+
+ifdef PDDIR
+  PDINCLUDEDIR := $(wildcard $(PDDIR)/src)
+endif
+
+# base path where all components of the lib will be installed by default
+installpath := $(DESTDIR)$(PDLIBDIR)/$(lib.name)
+
+# check if include path contains spaces (as is often the case on Windows)
+# if so, store the path so we can later do checks with it
+pdincludepathwithspaces := $(if $(word 2, $(PDINCLUDEDIR)), $(PDINCLUDEDIR))
+
+
+#=== accumulated build flags ===================================================
+
+
+# From GNU make docs: 'Users expect to be able to specify CFLAGS freely
+# themselves.' So we use CFLAGS to define options which  are not strictly
+# required for compilation: optimizations, architecture specifications, and
+# warnings. CFLAGS can be safely overriden using a make command argument.
+# Variables cflags, ldflags and ldlibs may be defined in including makefile.
+
+optimization.flags = -O3 -ffast-math -funroll-loops -fomit-frame-pointer
+warn.flags = -Wall -Wextra -Wshadow -Winline -Wstrict-aliasing
+
+# suppress -Wunused-variable & Co if you don't want to clutter a build log
+ifdef suppress-wunused
+  warn.flags += $(addprefix -Wno-unused-, function parameter value variable)
+endif
+
+CFLAGS = $(warn.flags) $(optimization.flags) $(arch.c.flags)
+
+# preprocessor flags
+cpp.flags := -DPD -I "$(PDINCLUDEDIR)" $(cpp.flags) $(CPPFLAGS)
+
+# flags for dependency checking (cflags from makefile may define -I options)
+depcheck.flags := $(cpp.flags) $(cflags)
+
+# architecture specifications for linker are overridable by LDFLAGS
+LDFLAGS := $(arch.ld.flags)
+
+# now add the same ld flags to shared dynamic lib
+shared.ldflags += $(LDFLAGS)
+
+# accumulated flags for C compiler / linker
+c.flags := $(cpp.flags) $(c.flags) $(cflags) $(CFLAGS)
+c.ldflags := $(c.ldflags) $(ldflags) $(LDFLAGS)
+c.ldlibs := $(c.ldlibs) $(ldlibs)
+
+# accumulated flags for C++ compiler / linker
+cxx.flags := $(cpp.flags) $(cxx.flags) $(cflags) $(CFLAGS)
+cxx.ldflags := $(cxx.ldflags) $(ldflags) $(LDFLAGS)
+cxx.ldlibs := $(cxx.ldlibs) $(ldlibs)
 
 
 ################################################################################
@@ -357,7 +669,7 @@ Makefile.pdlibbuilder = true
 # strip possibles spaces from lib.name, they mess up calculated file names
 lib.name := $(strip $(lib.name))
 
-# if meta file exists, check library version 
+# if meta file exists, check library version
 metafile := $(wildcard $(lib.name)-meta.pd)
 
 ifdef metafile
@@ -408,253 +720,21 @@ all.objects = $(classes.objects) $(common.objects) $(shared.objects) \
 #=== executables ===============================================================
 
 
-# use recursive variables here because executable extension is not yet known
-
 # construct class executable names from class names
-classes.executables = $(addsuffix .$(extension), $(classes))
+classes.executables := $(addsuffix .$(extension), $(classes))
 
-# construct shared lib executable name if shared sources are defined
+# Construct shared lib executable name if shared sources are defined. If
+# extension and shared extension are not identical, use both to facilitate co-
+# installation for different platforms, like .m_i386.dll and .m_amd64.dll.
 ifdef shared.sources
-  shared.lib = lib$(lib.name).$(shared.extension)
+  ifeq ($(extension), $(shared.extension))
+    shared.lib = lib$(lib.name).$(shared.extension)
+  else
+    shared.lib = lib$(lib.name).$(extension).$(shared.extension)
+  endif
 else
-  shared.lib =
+  shared.lib :=
 endif
-
-
-################################################################################
-### variables per platform #####################################################
-################################################################################
-
-
-#=== flags per architecture ====================================================
-
-
-# Set architecture-dependent cflags, mainly for Linux. For Mac and Windows, 
-# arch.c.flags are overriden below.
-
-machine := $(shell uname -m)
-
-# Raspberry Pi 1st generation
-ifeq ($(machine), armv6l)
-  arch.c.flags = -march=armv6 -mfpu=vfp -mfloat-abi=hard
-endif
-
-# Beagle, Udoo, RPi2 etc.
-ifeq ($(machine), armv7l)
-  arch.c.flags = -march=armv7-a -mfpu=vfpv3 -mfloat-abi=hard
-endif
-
-# Intel 32 bit, build with SSE and SSE2 instructions
-ifeq ($(findstring $(machine), i386 i686), $(machine))
-  arch.c.flags = -march=pentium4 -mfpmath=sse -msse -msse2
-endif
-
-# Intel/AMD 64 bit, build with SSE, SSE2 and SSE3 instructions
-ifeq ($(findstring $(machine), ia64 x86_64), $(machine))
-  arch.c.flags = -march=core2 -mfpmath=sse -msse -msse2 -msse3 
-endif
-
-
-#=== operating system ==========================================================
-
-
-# The following systems are defined: Linux, Darwin, Windows. GNU and
-# GNU/kFreeBSD are treated as Linux to get the same options. System-specific
-# multiline defines (optionally set in library makefile) are conditionally
-# evaluated here.
-
-uname := $(shell uname)
-
-ifeq ($(findstring $(uname), Linux GNU GNU/kFreeBSD), $(uname))
-  system = Linux
-  $(eval $(forLinux))
-endif
-
-ifeq ($(uname), Darwin)
-  system = Darwin
-  $(eval $(forDarwin))
-endif
-
-ifeq ($(findstring MINGW, $(uname)), MINGW)
-  system = Windows
-  $(eval $(forWindows))
-endif
-
-# TODO: Cygwin, Android
-
-
-#=== flags and paths for Linux =================================================
-
-
-ifeq ($(system), Linux)
-  prefix = /usr/local
-  libdir := $(prefix)/lib
-  pkglibdir = $(libdir)/pd-externals
-  pdincludepath := $(wildcard /usr/include/pd)
-  extension = pd_linux
-  cpp.flags := -DUNIX
-  c.flags := -fPIC
-  c.ldflags := -rdynamic -shared -fPIC -Wl,-rpath,"\$$ORIGIN",--enable-new-dtags
-  c.ldlibs := -lc -lm
-  cxx.flags := -fPIC -fcheck-new
-  cxx.ldflags := -rdynamic -shared -fPIC -Wl,-rpath,"\$$ORIGIN",--enable-new-dtags
-  cxx.ldlibs := -lc -lm -lstdc++
-  shared.extension = so
-  shared.ldflags := -rdynamic -fPIC -shared -Wl,-soname,$(shared.lib)
-  stripflags = --strip-unneeded -R .note -R .comment
-endif
-
-
-#=== flags and paths for Darwin ================================================
-
-
-# On OSX we try to build fat binaries by default. It is assumed that OSX i386
-# can build for ppc and OSX x86_64 can't. TODO: try to refine this condition.
-# LLVM-clang doesn't support -fcheck-new, therefore this flag is omitted for
-# OSX x86_64.
-
-
-ifeq ($(system), Darwin)
-  pkglibdir = $(HOME)/Library/Pd
-  pdincludepath := $(firstword $(wildcard \
-    /Applications/Pd*.app/Contents/Resources/src))
-  extension = pd_darwin
-  cpp.flags := -DUNIX -DMACOSX -I /sw/include
-  c.flags := 
-  c.ldflags := -undefined suppress -flat_namespace -bundle
-  c.ldlibs := -lc
-  cxx.ldflags := -undefined suppress -flat_namespace -bundle
-  cxx.ldlibs := -lc
-  shared.extension = dylib
-  shared.ldflags = -dynamiclib -undefined dynamic_lookup \
-    -install_name @loader_path/$(shared.lib) \
-    -compatibility_version 1 -current_version 1.0
-  stripflags = -x
-  version.flag := $(filter $(cflags), -mmacosx-version-min=%)
-  ifeq ($(machine), i386)
-    cxx.flags := -fcheck-new
-    arch := ppc i386 x86_64
-    version.flag ?= -mmacosx-version-min=10.4
-  endif
-  ifeq ($(machine), x86_64)
-    arch := i386 x86_64
-    version.flag ?= -mmacosx-version-min=10.5
-  endif
-  arch.c.flags := $(addprefix -arch , $(arch)) $(version.flag)
-  arch.ld.flags := $(arch.c.flags)
-endif
-
-
-#=== flags and paths for Windows ===============================================
-
-
-# Standard paths on Windows contain spaces, and GNU make functions treat such
-# paths as lists, with unintended effects. Therefore we must use shell function
-# ls instead of make's wildcard, and probe for each standard path individually.
-# Using double quotes around paths with spaces is obligatory. Since some path
-# variables are assembled or re-expanded later, great care must be taken to put
-# quotes at appropriate points throughout the makefile. Thanks, Bill.
-
-# paths for 32-bit executables on 64-bit Windows aren't yet defined here (TODO)
-ifeq ($(system), Windows)
-  pkglibdir := $(APPDATA)/Pd
-  ifndef pdbinpath
-    pdbinpath := $(shell ls -d "$(PROGRAMFILES)/pd/bin")
-  endif
-  ifndef pdincludepath
-    pdincludepath := $(shell ls -d "$(PROGRAMFILES)/pd/src")
-  endif
-endif
-
-# On Windows we build 32 bit by default to match Pd(-extended) binary 
-# distributions. This may change in the future.
-# TODO: decide whether -mms-bitfields should be specified.
-ifeq ($(system), Windows)
-  extension = dll
-  CC = gcc
-  CXX = g++
-  arch.c.flags := -march=pentium4 -msse -msse2 -mfpmath=sse
-  cpp.flags := -DMSW -DNT
-  c.flags :=
-  c.ldflags = -static-libgcc -shared \
-    -Wl,--enable-auto-import "$(pdbinpath)/pd.dll"
-  c.ldlibs :=
-  cxx.flags := -fcheck-new
-  cxx.ldflags = -static-libstdc++ -shared \
-    -Wl,--enable-auto-import "$(pdbinpath)/pd.dll"
-  cxx.ldlibs :=
-  shared.extension = dll
-  shared.ldflags = -static-libgcc -shared "$(pdbinpath)/pd.dll"
-  stripflags = --strip-unneeded -R .note -R .comment
-endif
-
-
-#=== paths =====================================================================
-
-
-# Platform-dependent default paths are specified above, but overridable.
-# Path variables in upper case can be defined as make command argument or in the
-# environment. 'PD_PATH' and 'objectsdir' are supported for compatibility with
-# the build system that pd-l2ork has inherited from pd-extended.
-
-PDDIR ?= $(PD_PATH)
-PDINCLUDEDIR ?= $(pdincludepath)
-PDBINDIR ?= $(pdbinpath)
-PDLIBDIR ?= $(firstword $(objectsdir) $(pkglibdir))
-
-ifneq ($(PDDIR),)
-  PDINCLUDEDIR := $(wildcard $(PDDIR)/src)
-  PDBINDIR := $(wildcard $(PDDIR)/bin)
-endif
-
-# base path where all components of the lib will be installed by default
-installpath := $(DESTDIR)$(PDLIBDIR)/$(lib.name)
-
-# check if include path contains spaces (as is often the case on Windows)
-# if so, store the path so we can later do checks with it
-pdincludepathwithspaces := $(if $(word 2, $(PDINCLUDEDIR)), $(PDINCLUDEDIR))
-
-
-#=== accumulated build flags ===================================================
-
-
-# From GNU make docs: 'Users expect to be able to specify CFLAGS freely
-# themselves.' So we use CFLAGS to define options which  are not strictly
-# required for compilation: optimizations, architecture specifications, and 
-# warnings. CFLAGS can be safely overriden using a make command argument.
-# Variables cflags, ldflags and ldlibs may be defined in including makefile.
-
-optimization.flags = -O3 -ffast-math -funroll-loops -fomit-frame-pointer
-warn.flags = -Wall -Wextra -Wshadow -Winline -Wstrict-aliasing
-
-# suppress -Wunused-variable & Co if you don't want to clutter a build log
-ifdef suppress-wunused
-  warn.flags += $(addprefix -Wno-unused-, function parameter value variable)
-endif
-
-CFLAGS = $(warn.flags) $(optimization.flags) $(arch.c.flags)
-
-# preprocessor flags
-cpp.flags := -DPD -I "$(PDINCLUDEDIR)" $(cpp.flags) $(CPPFLAGS)
-
-# flags for dependency checking (cflags from makefile may define -I options)
-depcheck.flags := $(cpp.flags) $(cflags)
-
-# architecture specifications for linker are overridable by LDFLAGS
-LDFLAGS := $(arch.ld.flags)
-
-# now add the same ld flags to shared dynamic lib
-shared.ldflags := $(shared.ldflags) $(LDFLAGS)
-
-# accumulated flags for C compiler / linker
-c.flags := $(cpp.flags) $(c.flags) $(cflags) $(CFLAGS)
-c.ldflags := $(c.ldflags) $(ldflags) $(LDFLAGS)
-c.ldlibs := $(c.ldlibs) $(ldlibs)
-
-# accumulated flags for C++ compiler / linker
-cxx.flags := $(cpp.flags) $(cxx.flags) $(cflags) $(CFLAGS)
-cxx.ldflags := $(cxx.ldflags) $(ldflags) $(LDFLAGS)
-cxx.ldlibs := $(cxx.ldlibs) $(ldlibs)
 
 
 ################################################################################
@@ -675,11 +755,23 @@ compile-cxx := $(CXX)
 # At this point most variables are defined. Now do some checks and info's
 # before rules begin.
 
+# print Makefile.pdlibbuilder version before possible termination
+$(info ++++ info: using Makefile.pdlibbuilder version $(version))
+
+# Terminate if target triplet remained empty, to avoid all sorts of confusing
+# scenarios and spurious bugs.
+ifeq ($(target.triplet),)
+  $(error Command "$(CC) -dumpmachine" did not return a target triplet, \
+  needed for a build. \
+  Is compiler "$(CC)" installed in your PATH? ($(PATH)). \
+  Does compiler "$(CC)" support option "-dumpmachine"?)
+endif
+
 # 'forward declaration' of default target, needed to do checks
 all:
 
 # To avoid unpredictable results, make sure the default target is not redefined
-# by including makefile. 
+# by including makefile.
 ifneq ($(.DEFAULT_GOAL), all)
   $(error Default target must be 'all'.)
 endif
@@ -696,8 +788,10 @@ ifdef PDINCLUDEDIR
   mpdh := $(shell ls "$(PDINCLUDEDIR)/m_pd.h")
 endif
 
-# print Makefile.pdlibbuilder version
-$(info ++++ info: using Makefile.pdlibbuilder version $(version))
+# store path to pd.dll; if not found, ls will give a useful error
+ifeq ($(system), Windows)
+  pddll := $(shell ls "$(PDBINDIR)/pd.dll")
+endif
 
 # when making target all, check if m_pd.h is found and print info about it
 ifeq ($(goals), all)
@@ -753,8 +847,8 @@ MAKEFLAGS += --no-builtin-rules
 
 
 # Target all forces the build of targets [$(executables) post] in
-# deterministic order. Target $(executables) builds class executables plus 
-# optional shared lib or alternatively a single lib executable when 
+# deterministic order. Target $(executables) builds class executables plus
+# optional shared lib or alternatively a single lib executable when
 # make-lib-executable=true. Target post is optionally defined by
 # library makefile.
 
@@ -827,13 +921,13 @@ endif
 define link-shared
   $(compile-$1) \
   $(shared.ldflags) \
-  -o lib$(lib.name).$(shared.extension) $(shared.objects) \
+  -o $(shared.lib) $(shared.objects) \
   $($1.ldlibs) $(shared.ldlibs)
 endef
 
 # rule for linking objects in shared executable
 # build recipe is in macro 'link-shared'
-lib$(lib.name).$(shared.extension): $(shared.objects)
+$(shared.lib): $(shared.objects)
 	$(info ++++ info: linking objects in shared lib $@)
 	$(if $(filter %.cc %.cpp, $(shared.sources)), \
         $(call link-shared,cxx), \
@@ -960,7 +1054,7 @@ endef
 %.pre:: %.cc force
 	$(call make-preprocessor-file,cxx)
 
-%.pre:: %.cpp force 
+%.pre:: %.cpp force
 	$(call make-preprocessor-file,cxx)
 
 
@@ -993,9 +1087,32 @@ endef
 ################################################################################
 
 
+#=== strip =====================================================================
+
+
+# Stripping of installed binaries will only be done when variable 'stripflags'
+# is defined non-empty. No default definition is provided except for Windows
+# where the unstripped binaries are large, especially in the case of Mingw-w64.
+
+# Note: while stripping all symbols ('-s' or '--strip-all') is possible for
+# Linux and Windows, in the case of OSX only non-global symbols can be stripped
+# (option '-x' or '--discard-all').
+
+# Make definition of strip command overridable so it can be defined in an
+# environment for cross-compilation.
+STRIP ?= strip
+
+# Commands in 'strip-executables' will be executed conditionally in the rule for
+# target 'install-executables'.
+strip-executables = cd "$(installpath)" && \
+  $(foreach v, $(executables), $(STRIP) $(stripflags) '$v';)
+
+
+#=== install ===================================================================
+
+
 # Install targets depend on successful exit status of target all because nothing
 # must be installed in case of a build error.
-
 
 # -p = preserve time stamps
 # -m = set permission mode (as in chmod)
@@ -1022,6 +1139,7 @@ install-executables: all
 	$(INSTALL_PROGRAM) '$v' "$(installpath)";)
 	$(info ++++ info: executables of lib $(lib.name) installed \
         from $(CURDIR) to $(installpath))
+	$(if $(stripflags), $(strip-executables),)
 
 install-datafiles: all
 	$(INSTALL_DIR) -v "$(installpath)"
@@ -1193,6 +1311,16 @@ help:
 	@echo
 	@echo "  Default paths are listed in the doc sections in Makefile.pdlibbuilder."
 	@echo
+
+
+#=== platform test =============================================================
+
+
+# This target can be used to test if the compiler for specified PLATFORM is
+# correctly defined and available.
+
+dumpmachine:
+	@$(CC) -dumpmachine
 
 
 #=== dummy target ==============================================================


### PR DESCRIPTION
This PR updates "Link" to v3.0.3 and "pd-lib-builder" to v0.6.0. These updates allow finishing Windows compilations without errors.

Tested (build and run) under Windows-10 and Debian-Buster both on i386 and amd64.

PS: For the Windows version I opted to statically link the pthread library. There are ways to not do this and include the pthread dll in the distribution. I can change this if needed.