### PR TITLE
replace error() with pd_error()

### DIFF
--- a/external/abl_link~.cpp
+++ b/external/abl_link~.cpp
@@ -113,7 +113,7 @@ static void abl_link_tilde_reset(t_abl_link_tilde *x, t_symbol *s,
   x->reset_flag = 1;
   switch (argc) {
     default:
-      error("abl_link~ reset: Unexpected number of parameters: %d", argc);
+      pd_error(x, "abl_link~ reset: Unexpected number of parameters: %d", argc);
     case 2:
       x->quantum = atom_getfloat(argv + 1);
     case 1:
@@ -140,7 +140,7 @@ static void *abl_link_tilde_new(t_symbol *s, int argc, t_atom *argv) {
   double initial_tempo = 120.0;
   switch (argc) {
     default:
-      error("abl_link~: Unexpected number of creation args: %d", argc);
+      pd_error(x, "abl_link~: Unexpected number of creation args: %d", argc);
     case 4:
       initial_tempo = atom_getfloat(argv + 3);
     case 3:

--- a/external/abl_link~.cpp
+++ b/external/abl_link~.cpp
@@ -185,5 +185,4 @@ void abl_link_tilde_setup() {
           gensym("offset"), A_DEFFLOAT, 0);
 }
 
-} //extern "C" 
-
+} //extern "C"


### PR DESCRIPTION
to allow compilation against Pd>=0.52 (where `error()` has been removed from the public API), this PR switches to `pd_error()` (which is nicer anyhow, as it allows the user to find the source of the error)

the PR also has some whitespace fix (in a separate commit)