### PR TITLE
Use the standard PDLIBBUILDER_DIR var for locating pd-lib-builder

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -39,8 +39,8 @@ define forWindows
   ldlibs += -lws2_32 -liphlpapi -static -lpthread
 endef
 
-PDLIBBUILDERDIR ?= .
-include $(PDLIBBUILDERDIR)/Makefile.pdlibbuilder
+PDLIBBUILDER_DIR ?= .
+include $(PDLIBBUILDER_DIR)/Makefile.pdlibbuilder
 
 VERSION = $(shell git describe)
 


### PR DESCRIPTION
Use the standard `PDLIBBUILDER_DIR` makefile-variable for locating pd-lib-builder rather than `PDLIBBUILDERDIR`.

The standardized variable name (as documented in https://github.com/pure-data/pd-lib-builder/blob/master/tips-tricks.md#project-management) simplifies packaging (as it allows us to use the same build-system invocation for virtually all pd-lib-builder based projects)